### PR TITLE
Fix TypeError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,10 +19,12 @@ module.exports = neutrino => {
   // Typescript compile rules
   config.module
     .rule('compile')
-    .test(/\.tsx?$/)
-    .loader('ts-loader', TS_LOADER, {
-      jsx: 'react'
-    });
+      .test(/\.tsx?$/)
+      .use('ts')
+        .loader(TS_LOADER)
+        .options({
+          jsx: 'react'
+        });
 
   // Resolve
   config.resolve.extensions.add('.ts');


### PR DESCRIPTION
Resolved a build error when running:

neutrino build --use neutrino-preset-node neutrino-preset-typescript

✖ Building project failed
TypeError: config.module.rule(...).test(...).loader is not a function
   at path/to/neutrino-preset-typescriptsrc/index.js:23:6)