### PR TITLE
Add copy config to ignore typescript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {},
   "bugs": "https://github.com/theodesp/neutrino-preset-typescript/issues",
   "dependencies": {
-    "awesome-typescript-loader": "^3.1.2"
+    "awesome-typescript-loader": "^3.1.2",
+    "neutrino-middleware-copy": "^5.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,17 @@ const path = require('path');
 const CWD = process.cwd();
 const SRC = path.join(CWD, 'src');
 const TS_LOADER = require.resolve('awesome-typescript-loader');
+const copy = require('neutrino-middleware-copy');
 
 module.exports = neutrino => {
   const { config } = neutrino; // Maps to basic webpack config options
+
+  if (process.env.NODE_ENV !== 'development') {
+    neutrino.use(copy, {
+      patterns: [{ context: neutrino.options.source, from: '**/*' }],
+      options: { ignore: ['*.ts*'] }
+    });
+  }
 
   // Replace index.js with index.ts
   config


### PR DESCRIPTION
Prevents typescript files from being copied to output directory
when running 'neutrino build'.